### PR TITLE
fix_random_grid_with_single_feature

### DIFF
--- a/pkg/R/grid.R
+++ b/pkg/R/grid.R
@@ -165,7 +165,7 @@ makeDesign = function(data, vars, n, uniform = TRUE, points, int.points) {
     } else {
       ## randomly sample points w/o replacement
       id = sample(1:nrow(data), n[1])
-      points = data[id, vars]
+      points = data[id, vars, drop = FALSE]
     }
   } else {
     uniform = FALSE


### PR DESCRIPTION
This did not work:

```r
X = replicate(3, rnorm(100))
y = X %*% runif(3)
data = data.frame(X, y)
fit = lm(y ~ ., data)

marginalPrediction(data.frame(X), "X2", c(10, 25), fit,
  aggregate.fun = function(x) c("mean" = mean(x), "variance" = var(x)), uniform = FALSE)
```